### PR TITLE
Update live-app-sdk dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:fix": "eslint --cache --fix src/** pages/**"
   },
   "dependencies": {
-    "@ledgerhq/live-app-sdk": "^0.5.0",
+    "@ledgerhq/live-app-sdk": "0.6.0",
     "@types/react-transition-group": "^4.4.3",
     "bignumber.js": "^9.0.1",
     "color": "^4.0.1",

--- a/src/Coinify/CoinifyWidget.tsx
+++ b/src/Coinify/CoinifyWidget.tsx
@@ -307,8 +307,8 @@ const CoinifyWidget = ({ account, currency, mode }: Props) => {
         provider: "coinify",
         fromAccountId: account.id,
         transaction: tx,
-        binaryPayload: coinifyContext.providerSig.payload,
-        signature: coinifyContext.providerSig.signature,
+        binaryPayload: Buffer.from(coinifyContext.providerSig.payload, "ascii"),
+        signature: Buffer.from(coinifyContext.providerSig.signature, "base64"),
         feesStrategy: FeesLevel.Medium,
         exchangeType: ExchangeType.SELL,
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -233,10 +233,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz#87de7af9c231826fdd68ac7258f77c429e0e5fcf"
   integrity sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==
 
-"@ledgerhq/live-app-sdk@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-app-sdk/-/live-app-sdk-0.5.0.tgz#1b41e2ae1b8c0da63528cc4ae90acfc9aa5c546e"
-  integrity sha512-5uiNXKgkF9FJ514hKJtvBS3I31Gx5lIkS8VIiKeq+Mnch1RtS6rjKr/ODykUD1rgmDU557fNMEDtZHbFPNI4Hg==
+"@ledgerhq/live-app-sdk@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-app-sdk/-/live-app-sdk-0.6.0.tgz#65595132d73bd3834feafdaa34ad6aa87fb133b1"
+  integrity sha512-I4EfXn77Yz8jehgXPj61pgcfjW018eaCBOOBmfdDtYRTNQ5N3vybnEFjVJy16RMjphfKvZqs68r6ooY6o35/qQ==
   dependencies:
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"


### PR DESCRIPTION
### Description
`completeExchange` now uses `Buffer` instead of `string` for `binaryPayload` and `signature` arguments

🔗  https://github.com/LedgerHQ/live-app-sdk/pull/37

### TODO:

- [x] Update dep when https://github.com/LedgerHQ/live-app-sdk/pull/37 merged